### PR TITLE
DBT-965 DBT-970 DBT-973 Version 2.2.4

### DIFF
--- a/app/Http/Controllers/Api/v1/LessonsController.php
+++ b/app/Http/Controllers/Api/v1/LessonsController.php
@@ -711,6 +711,10 @@ class LessonsController extends Controller
 
             $lesson->materials()->save($material);
 
+            if ($lesson->is_active) {
+                $lesson->notifyUsers();
+            }
+
             return response()->json([
                 'status' => 'successfully'
             ]);

--- a/app/Http/Controllers/Api/v1/LessonsController.php
+++ b/app/Http/Controllers/Api/v1/LessonsController.php
@@ -712,7 +712,7 @@ class LessonsController extends Controller
             $lesson->materials()->save($material);
 
             if ($lesson->is_active) {
-                $lesson->notifyUsers();
+                $lesson->notifyNewMaterial($material);
             }
 
             return response()->json([

--- a/app/Http/Controllers/Api/v1/LessonsController.php
+++ b/app/Http/Controllers/Api/v1/LessonsController.php
@@ -540,8 +540,8 @@ class LessonsController extends Controller
                 ], 404);
             }
 
-            // Will delete any student that doesnt belong to the group anymore. Add the current active ones
-            $result = $lesson->students()->newPivotStatement()->where('group_id', $group->id)->delete();
+            // Delete all the students of the group for this lesson
+            $result = DB::table('lesson_user')->where('group_id', $group->id)->where('lesson_id', $lesson->id)->delete();
 
             return response()->json([
                 'status' => 'successfully',

--- a/app/Http/Controllers/Api/v1/LessonsController.php
+++ b/app/Http/Controllers/Api/v1/LessonsController.php
@@ -419,6 +419,7 @@ class LessonsController extends Controller
      * Lesson Student: Add Group
      *
      * Sync group of active students to a lesson.
+     * Return the total of students of that group in the lesson
      * @authenticated
      * @urlParam lessonId integer required Lesson ID
      * @response {"message": "successfully", "count": 10 }
@@ -446,12 +447,12 @@ class LessonsController extends Controller
 
 
 
-            $studentsIds = $lesson->syncGroup($group);
+            $countAfterSync = $lesson->syncGroup($group);
 
 
             return response()->json([
                 'status' => 'successfully',
-                'count' => count($studentsIds)
+                'count' => $countAfterSync
             ]);
 
         } catch (\Exception $err) {

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Notifications\Api\NewLessonAvailable;
+use App\Notifications\Api\NewMaterialAvailable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -129,6 +130,22 @@ class Lesson extends Model
             $student->notify(
                 new NewLessonAvailable(
                     $lesson
+                )
+            );
+        }
+    }
+
+    public function notifyNewMaterial(Material $material)
+    {
+
+        $students = $this->students()->get();
+        $lesson = Lesson::find($this->id); // Get a fresh copy of the lesson
+
+        foreach ($students as $student) {
+            $student->notify(
+                new NewMaterialAvailable(
+                    $lesson,
+                    $material
                 )
             );
         }

--- a/app/Notifications/Api/NewMaterialAvailable.php
+++ b/app/Notifications/Api/NewMaterialAvailable.php
@@ -3,6 +3,7 @@
 namespace App\Notifications\Api;
 
 use App\Models\Lesson;
+use App\Models\Material;
 use App\Models\Opposition;
 use App\Models\Question;
 use App\Models\Topic;
@@ -12,19 +13,22 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class NewLessonAvailable extends Notification implements ShouldQueue
+class NewMaterialAvailable extends Notification implements ShouldQueue
 {
     use Queueable;
 
     private Lesson $lesson;
+    private Material $material;
 
     /**
      * @param Lesson $lesson
+     * @param Material $material
      */
-    public function __construct(Lesson $lesson)
+    public function __construct(Lesson $lesson, Material $material)
     {
 
         $this->lesson = $lesson;
+        $this->material = $material;
 
     }
 
@@ -38,10 +42,10 @@ class NewLessonAvailable extends Notification implements ShouldQueue
         $date = date('d/m/Y', strtotime($this->lesson->date));
 
         return (new MailMessage)
-            ->subject("Clase {$this->lesson->name} disponible")
+            ->subject("Clase {$this->lesson->name} - Nuevo Material")
             ->greeting("<p class='center-text text-size-20 typography-greeting-text'>{$this->lesson->name}</p>")
-            ->line("Hola! La clase  {$this->lesson->name} del día {$date} ya se encuentra activada.")
-            ->line('Podrás consultar los archivos vinculados a la misma desde tu área "Mis Clases". Así mismo, en tu apartado "Materiales", aparecerán los nuevos documentos.')
+            ->line(" Se ha incorporado el material {$this->material->name} a la clase {$this->lesson->name} del día {$date}.")
+            ->line('Podrás consultarlo desde  “Mis Clases" o en el apartado "Materiales".')
             ->line("¡A darle caña!")
             ->salutation("Firma");
     }


### PR DESCRIPTION
## Context

- [DBT-965](https://www.notion.so/tianlu/Resyncing-groups-is-erasing-the-assitance-ebd8018c43474a08aa8c60056ef09a93?pvs=4) When the Group is Sync, the data of the students who are still in the group is not reset (will_join) and is not deleted.
- [DBT-970](https://www.notion.so/tianlu/Send-an-email-when-a-material-is-upload-to-an-already-active-lesson-90d40184c0934d47a37b5eb230e5ba1c?pvs=4) Notify the users when a material is uploaded to an active lesson
- [DBT-973](https://www.notion.so/tianlu/Removing-a-group-form-a-lesson-will-affect-to-other-lessons-8c5e89fdb25f498f84033640bb927652?pvs=4) Remove groups from a lesson is removing them from ALL the lessons

